### PR TITLE
modify default .env DB password to Jesse's default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DB_HOST='127.0.0.1'
 DB_NAME=jesse_db
 DB_USER=jesse_user
-DB_PASSWORD=jesse_psw
+DB_PASSWORD=password
 DB_PORT=5432


### PR DESCRIPTION
Changes it to what the password would be if the user follows db creation commands from the documentation